### PR TITLE
Fix trigger recording logic

### DIFF
--- a/UwUinator/DynamicTriggerManager.cs
+++ b/UwUinator/DynamicTriggerManager.cs
@@ -103,10 +103,12 @@ namespace UwUinator
         public void RecordTrigger()
         {
             lock (_lock)
+            {
                 if (_triggerTimestamps.Count > _maxTriggersPerWindow)
                     return;
-            {
+
                 var timestamp = DateTime.UtcNow;
+                _triggerTimestamps.Enqueue(timestamp);
                 _logger.LogDebug("[RecordTrigger] Trigger recorded at {Timestamp}. Total triggers: {TriggerCount}",
                     timestamp, _triggerTimestamps.Count);
                 RemoveOldTimestamps(_triggerTimestamps);


### PR DESCRIPTION
## Summary
- fix `RecordTrigger` so trigger timestamps are stored

## Testing
- `dotnet build --nologo`
- `dotnet test --no-build --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6843400ed7148320b6726ba3ef5ad2c6