### PR TITLE
Fix handler naming and dynamic trigger logic

### DIFF
--- a/UwUinator/DynamicTriggerManager.cs
+++ b/UwUinator/DynamicTriggerManager.cs
@@ -51,16 +51,15 @@ namespace UwUinator
         {
             if (!ShouldConsiderMessage(message))
                 return;
-            {
-                var timestamp = DateTime.UtcNow;
-                _logger.LogDebug("[RecordMessage] Message recorded at {Timestamp}. Content: \"{Content}\"",
-                    timestamp, message.Content);
-                _messageTimestamps.Enqueue(timestamp);
-                AdjustScalingFactors();
-                RemoveOldTimestamps(_messageTimestamps);
-                _logger.LogDebug("[RecordMessage] Total messages after cleanup: {MessageCount}",
-                    _messageTimestamps.Count);
-            }
+
+            var timestamp = DateTime.UtcNow;
+            _logger.LogDebug("[RecordMessage] Message recorded at {Timestamp}. Content: \"{Content}\"",
+                timestamp, message.Content);
+            _messageTimestamps.Enqueue(timestamp);
+            AdjustScalingFactors();
+            RemoveOldTimestamps(_messageTimestamps);
+            _logger.LogDebug("[RecordMessage] Total messages after cleanup: {MessageCount}",
+                _messageTimestamps.Count);
         }
 
         /// <summary>

--- a/UwUinator/UwUifyMessageHandler.cs
+++ b/UwUinator/UwUifyMessageHandler.cs
@@ -16,7 +16,7 @@ namespace UwUinator
         private readonly HashSet<string> _recentFeatures = new();
 
         private readonly DynamicTriggerManager _triggerManager;
-        
+
         public UwUifyMessageHandler(ILogger<UwUifyMessageHandler> logger)
         {
             _logger = logger;
@@ -107,7 +107,7 @@ namespace UwUinator
             uwuified = AddSeasonalFlair(uwuified);
             uwuified = AddMoodEnhancements(uwuified);
             uwuified = AddRelevantEmojis(uwuified);
-            
+
             uwuified = Regex.Replace(uwuified, "[rl]", "w");
             uwuified = Regex.Replace(uwuified, "[RL]", "W");
 
@@ -281,7 +281,7 @@ namespace UwUinator
             }
 
             // Add responses based on message length
-            if (input.Length > 500 &&  _random.NextDouble() < 0.1)
+            if (input.Length > 500 && _random.NextDouble() < 0.1)
             {
                 input += Environment.NewLine +
                          "UwU dat’s a wot of wowds nya~!! 😺 *twies 2 wead awe of it weawwy fast!*";
@@ -425,7 +425,7 @@ namespace UwUinator
             {
                 input += Environment.NewLine + musicResponses[_random.Next(musicResponses.Length)];
             }
-            
+
             if (DateTime.Now.Hour % 12 == 0 && DateTime.Now.Minute == 0) // Example: Time-Based Enhancement
             {
                 input += Environment.NewLine + "Hewwooo! UwU dis is a time-special magical weply OwO ♥!";


### PR DESCRIPTION
## Summary
- fix the stray code block in `DynamicTriggerManager.RecordMessage`
- rename `UwUifyMessageHanfdler.cs` to `UwUifyMessageHandler.cs` for clarity

## Testing
- `dotnet build UwUinator/UwUinator.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68434170347083208e71c55248e350a6