### PR TITLE
Improve trigger control with per-guild backoff

### DIFF
--- a/UwUinator/UwUifyMessageHandler.cs
+++ b/UwUinator/UwUifyMessageHandler.cs
@@ -51,7 +51,7 @@ namespace UwUinator
                 return;
             }
 
-            _triggerManager.RecordTrigger();
+            _triggerManager.RecordTrigger(message);
 
             // Pre-Typing Messages (introduce anticipation)
             _logger.LogInformation(


### PR DESCRIPTION
## Summary
- control trigger chance on a per-guild basis
- apply exponential backoff for active guilds
- update message handler to pass messages to `RecordTrigger`

## Testing
- `dotnet build UwUinator/UwUinator.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684742ff2c7c83208d56083d18185c08