### PR TITLE
Fix Docker tagging case in workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -24,6 +24,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set lowercase repository value
+        run: echo "REPO_LC=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -31,5 +33,5 @@ jobs:
           file: UwUinator/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/uwuinator:latest
-            ghcr.io/${{ github.repository }}/uwuinator:${{ github.ref_name }}
+            ghcr.io/${{ env.REPO_LC }}/uwuinator:latest
+            ghcr.io/${{ env.REPO_LC }}/uwuinator:${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- convert repository name to lowercase before tagging

## Testing
- `dotnet restore UwUinator.sln`
- `dotnet build UwUinator.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6849b64455dc8320a30ee64a4c14d73d